### PR TITLE
Container autosizing

### DIFF
--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -200,8 +200,11 @@ export default class StudioApp {
     return imageUrls;
   }
 
-  // Removes a tag from the document and everything located completely
-  // below it is shifted up, vertically
+  /**
+   * Remove a tag from the document, find all tags located
+   * completely below it, and shift them all up, vertically. Sort
+   * of a "splice()" for tags.
+   */
   sliceOutTag(tag) {
     const height = tag.height;
     const tagsBelow = this.tags.filter(t => t.top >= tag.top + height);
@@ -216,8 +219,11 @@ export default class StudioApp {
     this.allTags = this.allTags.filter(t => t !== tag);
   }
 
-  // resizes the container to just bound around the tag elements
-  // inside it
+  /**
+   * Resize the container to fit exactly around the tag elements
+   * inside it. Can be passed padding. Note that it currently does
+   * not trim extra space on the top or left of the container.
+   */
   fitToTags(padding = {}) {
     const boundingBox = this.innerBoundingBox();
 
@@ -230,7 +236,9 @@ export default class StudioApp {
     this.container.style.height = height + 'px';
   }
 
-  // finds a bounding box of all tags
+  /**
+   * Find a bounding box of the given tags.
+   */
   innerBoundingBox(tags = this.tags) {
     let top = Infinity;
     let left = Infinity;
@@ -252,13 +260,16 @@ export default class StudioApp {
       right = Math.max(right, boundingBox.right - containerLeft);
     });
 
+    const width = right - left;
+    const height = bottom - top;
+
     return {
       top,
       left,
       right,
       bottom,
-      width: right - left,
-      height: bottom - top
+      width,
+      height
     };
   }
 

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -7,9 +7,11 @@ export default class StudioApp {
    * operations. It is highly recommended that you declare all of your params
    * by setting instance variables via `this.thing = this.param(...)` up front.
    */
-  constructor() {
+  constructor(container) {
+    this.container = container || document.querySelector('#mi_size_container');
     this._setOptions();
     this._setTags();
+    this._getBounding();
   }
 
   /**
@@ -198,6 +200,68 @@ export default class StudioApp {
     return imageUrls;
   }
 
+  // Removes a tag from the document and everything located completely
+  // below it is shifted up, vertically
+  sliceOutTag(tag) {
+    const height = tag.height;
+    const tagsBelow = this.tags.filter(t => t.top >= tag.top + height);
+    tagsBelow.forEach(t => {
+      t.top -= height;
+      t.element.style.top = t.top + 'px';
+    });
+
+    tag.element.parentNode.removeChild(tag.element);
+
+    this.tags = this.tags.filter(t => t !== tag);
+    this.allTags = this.allTags.filter(t => t !== tag);
+  }
+
+  // resizes the container to just bound around the tag elements
+  // inside it
+  fitToTags(padding = {}) {
+    const boundingBox = this.innerBoundingBox();
+
+    const width = boundingBox.width + (padding.left || 0) + (padding.right || 0);
+    const height = boundingBox.height + (padding.top || 0) + (padding.bottom || 0);
+
+    this.container.removeAttribute('width');
+    this.container.removeAttribute('height');
+    this.container.style.width = width + 'px';
+    this.container.style.height = height + 'px';
+  }
+
+  // finds a bounding box of all tags
+  innerBoundingBox(tags = this.tags) {
+    let top = Infinity;
+    let left = Infinity;
+    let right = -Infinity;
+    let bottom = -Infinity;
+
+    if (!tags.length) {
+      return { top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0 };
+    }
+
+    const containerTop = this.container.offsetTop;
+    const containerLeft = this.container.offsetLeft;
+
+    tags.map(t => t.element).forEach(el => {
+      const boundingBox = el.getBoundingClientRect();
+      top = Math.min(top, boundingBox.top - containerTop);
+      left = Math.min(left, boundingBox.left - containerLeft);
+      bottom = Math.max(bottom, boundingBox.bottom - containerTop);
+      right = Math.max(right, boundingBox.right - containerLeft);
+    });
+
+    return {
+      top,
+      left,
+      right,
+      bottom,
+      width: right - left,
+      height: bottom - top
+    };
+  }
+
   // Private Methods
 
   /**
@@ -250,5 +314,19 @@ export default class StudioApp {
         this.fields[field.name] = field.value;
       });
     }
+  }
+
+  /**
+   * Pre-sets originalBounding and originalPadding, to store the
+   * amount of padding between tags and the sides of the container
+   */
+  _getBounding() {
+    this.originalBounding = this.innerBoundingBox();
+    this.originalPadding = {
+      top: this.originalBounding.top,
+      left: this.originalBounding.left,
+      bottom: this.container.getAttribute('height') - this.originalBounding.height,
+      right: this.container.getAttribute('width') - this.originalBounding.width
+    };
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -247,3 +247,73 @@ QUnit.test('.waitForImageAssets with img tags', function(assert) {
   assert.equal(images.length, 1);
   assert.expect(2);
 });
+
+QUnit.test('.container', function(assert) {
+  const app = new StudioApp();
+  assert.equal(app.container.id, 'mi_size_container');
+});
+
+QUnit.test('.innerBoundingBox', function(assert) {
+  const app = new StudioApp();
+  assert.equal(app.innerBoundingBox().top, 111, 'has correct top');
+  assert.equal(app.innerBoundingBox().left, 62, 'has correct left');
+  assert.equal(app.innerBoundingBox().bottom, 171, 'has correct bottom');
+  assert.equal(app.innerBoundingBox().right, 338, 'has correct right');
+  assert.equal(app.innerBoundingBox().width, 276, 'has correct width');
+  assert.equal(app.innerBoundingBox().height, 60, 'has correct height');
+});
+
+QUnit.test('.innerBoundingBox with args', function(assert) {
+  const app = new StudioApp();
+  const tags = app.tags.slice(0, 1);
+  const tag = tags[0];
+  assert.equal(app.innerBoundingBox(tags).top, tag.top, 'has correct top');
+  assert.equal(app.innerBoundingBox(tags).left, tag.left, 'has correct left');
+  assert.equal(app.innerBoundingBox(tags).bottom, 171, 'has correct bottom');
+  assert.equal(app.innerBoundingBox(tags).right, 338, 'has correct right');
+  assert.equal(app.innerBoundingBox(tags).width, tag.width, 'has correct width');
+  assert.equal(app.innerBoundingBox(tags).height, tag.height, 'has correct height');
+});
+
+QUnit.test('.innerBoundingBox with empty array', function(assert) {
+  const app = new StudioApp();
+  const tags = [];
+  assert.equal(app.innerBoundingBox(tags).top, 0, 'has correct top');
+  assert.equal(app.innerBoundingBox(tags).left, 0, 'has correct left');
+  assert.equal(app.innerBoundingBox(tags).bottom, 0, 'has correct bottom');
+  assert.equal(app.innerBoundingBox(tags).right, 0, 'has correct right');
+  assert.equal(app.innerBoundingBox(tags).width, 0, 'has correct width');
+  assert.equal(app.innerBoundingBox(tags).height, 0, 'has correct height');
+});
+
+QUnit.test('.fitToTags', function(assert) {
+  const app = new StudioApp();
+  app.fitToTags();
+
+  assert.equal(app.container.style.width, '276px', 'resizes the width');
+  assert.equal(app.container.style.height, '60px', 'resizes the height');
+});
+
+QUnit.test('.fitToTags with padding', function(assert) {
+  const app = new StudioApp();
+  app.fitToTags({ top: 5, bottom: 3, left: 10, right: 44 });
+
+  assert.equal(app.container.style.width, '330px', 'resizes the width');
+  assert.equal(app.container.style.height, '68px', 'resizes the height');
+});
+
+QUnit.test('.sliceOutTag', function(assert) {
+  const app = new StudioApp();
+  const hours = app.tags.find(t => t.tool.name === 'hours');
+  assert.equal(hours.top, 131, 'hours element starts at 131');
+  const text = app.tags.filter(t => t.tool.name === 'text');
+
+  text.forEach(t => {
+    app.sliceOutTag(t);
+  });
+
+  assert.equal(hours.top, 111, 'moves the hours element up 20px');
+
+  assert.notOk(app.tags.find(t => t.tool.name === 'text'), 'removes text tags from tag list');
+  assert.notOk(app.allTags.find(t => t.tool.name === 'text'), 'removes text tags from all tags');
+});


### PR DESCRIPTION
Adds a few new methods on `StudioApp`:

- `innerBoundingBox` - finds a bounding box around the passed tags (or this.tags)
- `sliceOutTag` - removes a tag from the container, and shifts everything below it up by the tag's height
- `fitToTags` - adjusts the container's width and height to fit the tags it contains

So a common usage of this might be something like:
```
const image = this.tags.find(t => t.tool.name === 'image');
if(doNotShowImages) {
  this.sliceOutTag(image);
  this.fitToElements(this.originalPadding);
}
```

This will remove an image tag and shift everything below it up, while maintaining the same padding between the tags and the edges of the container.
