### PR TITLE
Zm/wait for background images from dom

### DIFF
--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -185,20 +185,16 @@ export default class StudioApp {
       ...document.querySelectorAll('img')
     ].map(({ src }) => src);
 
-    const backgroundImageUrlsFromDom = [
+    const backgroundImageUrls = [
       ...document.querySelectorAll('[style*="background-image"]')
     ].map(({ style }) => {
       const { backgroundImage } = style;
       return backgroundImage.replace(/^url\((.*)\)$/g, '$1');
     });
 
-    const backgroundImageUrlsFromTags = this.allTags.map(
-      ({ backgroundImage }) => backgroundImage);
-
     const imageUrls = [
       ...imageSrcUrls,
-      ...backgroundImageUrlsFromDom,
-      ...backgroundImageUrlsFromTags
+      ...backgroundImageUrls
     ].filter(url => url && url !== 'none');
 
     imageUrls.forEach(image => {

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -181,15 +181,25 @@ export default class StudioApp {
    * render.
    */
   waitForImageAssets() {
-    const imageEls = Array.from(document.querySelectorAll('img'));
-    const tagsWithBackgrounds = this.allTags.filter(t => {
-      return t.backgroundImage && t.backgroundImage !== 'none';
+    const imageSrcUrls = [
+      ...document.querySelectorAll('img')
+    ].map(({ src }) => src);
+
+    const backgroundImageUrlsFromDom = [
+      ...document.querySelectorAll('[style*="background-image"]')
+    ].map(({ style }) => {
+      const { backgroundImage } = style;
+      return backgroundImage.replace(/^url\((.*)\)$/g, '$1');
     });
 
-    const urlsFromBackgrounds = tagsWithBackgrounds.map(t => t.backgroundImage);
-    const urlsFromImgTags = imageEls.map(el => el.src);
+    const backgroundImageUrlsFromTags = this.allTags.map(
+      ({ backgroundImage }) => backgroundImage);
 
-    const imageUrls = urlsFromBackgrounds.concat(urlsFromImgTags);
+    const imageUrls = [
+      ...imageSrcUrls,
+      ...backgroundImageUrlsFromDom,
+      ...backgroundImageUrlsFromTags
+    ].filter(url => url && url !== 'none');
 
     imageUrls.forEach(image => {
       CD.waitForAsset(image);

--- a/test/tests.js
+++ b/test/tests.js
@@ -215,22 +215,7 @@ QUnit.test('.waitForImageAssets with no images', function(assert) {
   assert.equal(images.length, 0);
 });
 
-QUnit.test('.waitForImageAssets with background images in tags', function(assert) {
-  const app = new StudioApp();
-  const tag = app.tags.find(t => t.text === '[hours]');
-  tag.backgroundImage = 'http://example.com/image.png';
-
-  CD.log = function(msg) {
-    assert.equal(msg, 'Wait for asset: http://example.com/image.png');
-  };
-
-  const images = app.waitForImageAssets();
-
-  assert.equal(images.length, 1);
-  assert.expect(2);
-});
-
-QUnit.test('.waitForImageAssets with background images added to DOM', function(assert) {
+QUnit.test('.waitForImageAssets with background images', function(assert) {
   const backgroundImage = 'http://example.com/image.png';
 
   const app = new StudioApp();

--- a/test/tests.js
+++ b/test/tests.js
@@ -215,13 +215,30 @@ QUnit.test('.waitForImageAssets with no images', function(assert) {
   assert.equal(images.length, 0);
 });
 
-QUnit.test('.waitForImageAssets with background images', function(assert) {
+QUnit.test('.waitForImageAssets with background images in tags', function(assert) {
   const app = new StudioApp();
   const tag = app.tags.find(t => t.text === '[hours]');
   tag.backgroundImage = 'http://example.com/image.png';
 
   CD.log = function(msg) {
     assert.equal(msg, 'Wait for asset: http://example.com/image.png');
+  };
+
+  const images = app.waitForImageAssets();
+
+  assert.equal(images.length, 1);
+  assert.expect(2);
+});
+
+QUnit.test('.waitForImageAssets with background images added to DOM', function(assert) {
+  const backgroundImage = 'http://example.com/image.png';
+
+  const app = new StudioApp();
+  const { element } = app.tags.find(t => t.text === '[hours]');
+  element.style.setProperty('background-image', `url("${backgroundImage}")`);
+
+  CD.log = function(msg) {
+    assert.equal(msg, `Wait for asset: "${backgroundImage}"`);
   };
 
   const images = app.waitForImageAssets();


### PR DESCRIPTION
`StudioApp.prototype.waitForImageAssets` currently does not look for background urls that are not present in the app on load. This means that when an app populates a background image url from an API response (like in the twitter app), the method will miss those elements.

This is not a problem for image `src`s, because the method looks for that property in the DOM.

This revision updates the `waitForImageAssets` method to search the DOM for background images also.