### PR TITLE
StudioApp container

### DIFF
--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -7,7 +7,8 @@ export default class StudioApp {
    * operations. It is highly recommended that you declare all of your params
    * by setting instance variables via `this.thing = this.param(...)` up front.
    */
-  constructor() {
+  constructor({ container } = {}) {
+    this.container = container || document;
     this._setOptions();
     this._setTags();
   }
@@ -211,6 +212,7 @@ export default class StudioApp {
     this.tags = [];
     this.allTags = [];
     const attributesElement = document.querySelector('.mi-attributes');
+    const { container } = this;
 
     const flattenTags = function(tags) {
       tags.forEach(t => {
@@ -227,7 +229,7 @@ export default class StudioApp {
         flattenTags(this.tags);
 
         this.allTags.forEach(tag => {
-          tag.element = document.querySelector(`[mi-tag='${tag.id}']`);
+          tag.element = container.querySelector(`[mi-tag='${tag.id}']`);
         });
       } catch (e) {
         console.log('Error parsing the attributes element: ' + e);

--- a/test/tests.js
+++ b/test/tests.js
@@ -265,3 +265,37 @@ QUnit.test('DataSource.getRawData', function(assert) {
   const ds = new DataSource({ key: 'foo' });
   ds.getRawData({ name: 'something', another: 'something else' });
 });
+
+QUnit.test('container', function(assert) {
+  assert.ok(
+    new StudioApp().container,
+    document,
+    'it sets the document as the container by default'
+  );
+
+  const container2 = document.querySelector('#mi_size_container').cloneNode(true);
+  container2.setAttribute('id', 'mi_size_container_2');
+  [...container2.children].forEach(child => child.classList.add('container-2'));
+
+  const container1 = document.querySelector('#mi_size_container');
+  [...container1.children].forEach(child => child.classList.add('container-1'));
+
+  container1.append(container2);
+
+  const app1 = new StudioApp({ container: container1 });
+  const app2 = new StudioApp({ container: container2 });
+
+  assert.equal(app1.container, container1, 'it assigns a container');
+  assert.equal(app1.tags.length, 11);
+  assert.ok(
+    app1.tags.every(({ element }) => element.classList.contains('container-1')),
+    'it scopes tags to its container'
+  );
+
+  assert.equal(app2.container, container2, 'it correctly assigns a container');
+  assert.equal(app2.tags.length, 11);
+  assert.ok(
+    app2.tags.every(({ element }) => element.classList.contains('container-2')),
+    'it scopes tags to its container'
+  );
+});


### PR DESCRIPTION
The twitter app (and others that have "tiling") need a little help integrating with MDK.

We are exploring a pattern where the API call is made outside of the app class, and iterating through the response calls a factory method which returns class instances that inherit from StudioApp.

By cloning the WYSIWYG html once per instance and setting it as a `container`, the tags are appropriately associated with the proper elements within their containers.

Todo:
- [x] Add tests