### PR TITLE
lazy getters for everything!

### DIFF
--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -202,6 +202,10 @@ export default class StudioApp {
    * a flat list of all tags, associated with their DOM elements
    */
   get allTags() {
+    if (this._allTags) {
+      return this._allTags;
+    }
+
     const flattenTags = (nestedTags = []) => {
       return nestedTags.reduce((flattened, tag) => {
         const { subtags } = tag;
@@ -209,15 +213,19 @@ export default class StudioApp {
       }, []);
     };
 
-    return flattenTags(this.tags);
+    const tags = this._allTags = flattenTags(this.tags);
+    return tags;
   }
 
   /**
    * a list of tags with nested subtags, associated with their DOM elements
    */
   get tags() {
-    const { container } = this;
-    const tags = JSON.parse(document.querySelector('.mi-attributes').textContent);
+    if (this._tags) {
+      return this._tags;
+    }
+
+    const unassignedTags = JSON.parse(document.querySelector('.mi-attributes').textContent);
 
     const setElements = tags => {
       tags.forEach(tag => {
@@ -226,7 +234,7 @@ export default class StudioApp {
       });
     };
 
-    setElements(tags);
+    const tags = this._tags = setElements(unassignedTags);
     return tags;
   }
 
@@ -245,11 +253,17 @@ export default class StudioApp {
    * A safer way to access manifest field values
    */
   get fields() {
+    if (this._fields) {
+      return this._fields;
+    }
+
     const optionFields = this.options.fields || [];
 
-    return optionFields.reduce((fields, { name, value }) => {
+    const fieldsObject = this._fields = optionFields.reduce((fields, { name, value }) => {
       fields[name] = value;
       return fields;
     }, {});
+
+    return fieldsObject;
   }
 }

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -225,6 +225,7 @@ export default class StudioApp {
       return this._tags;
     }
 
+    const { container } = this;
     const unassignedTags = JSON.parse(document.querySelector('.mi-attributes').textContent);
 
     const setElements = tags => {
@@ -232,6 +233,8 @@ export default class StudioApp {
         tag.element = container.querySelector(`[mi-tag='${tag.id}']`);
         setElements(tag.subtags || []);
       });
+
+      return tags;
     };
 
     const tags = this._tags = setElements(unassignedTags);

--- a/test/tests.js
+++ b/test/tests.js
@@ -21,6 +21,33 @@ QUnit.test('it instantiates a studio app', function(assert) {
   assert.equal(app.tags.length, 11);
 });
 
+QUnit.test('all tags getter', function(assert) {
+  const app = new StudioApp();
+  assert.notOk(app._allTags, '_allTags is not defined in constructor');
+  const allTags = app.allTags;
+  assert.deepEqual(app.allTags, app._allTags, 'calling getter defines _allTags');
+  app._allTags = 'foo';
+  assert.equal(app.allTags, 'foo', 'getter returns _allTags if defined');
+});
+
+QUnit.test('tags getter', function(assert) {
+  const app = new StudioApp();
+  assert.notOk(app._tags, '_tags is not defined in constructor');
+  const tags = app.tags;
+  assert.deepEqual(app.tags, app._tags, 'calling getter defines _tags');
+  app._tags = 'foo';
+  assert.equal(app.tags, 'foo', 'getter returns _tags if defined');
+});
+
+QUnit.test('fields getter', function(assert) {
+  const app = new StudioApp();
+  assert.notOk(app._fields, '_fields is not defined in constructor');
+  const fields = app.fields;
+  assert.deepEqual(app.fields, app._fields, 'calling getter defines _fields');
+  app._fields = 'foo';
+  assert.equal(app.fields, 'foo', 'getter returns _fields if defined');
+});
+
 QUnit.test('.param with required value missing', function(assert) {
   mockParams({ foo: null });
 


### PR DESCRIPTION
Currently, our constructor calls private methods to build out some internal state. It would be more declarative to instead use ES6 getters for these properties.

This gives us a couple added benefits of not having to track whether or not these methods need to be called again whenever these instance properties are updated, as well as making the properties evaluate lazily.