### PR TITLE
studio app methods to crop or contain images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio-app",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Base class for building Studio-based Movable Ink applications",
   "keywords": [
     "movableink",

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -199,17 +199,18 @@ export default class StudioApp {
   }
 
   cropImage(element) {
-    element.style['background-size'] = 'cover';
+    element.style.setProperty('background-size', 'unset');
+    element.style.setProperty('background-position', 'unset');
+    element.style.setProperty('background-repeat', 'no-repeat');
     return element;
   }
 
   containImage(element) {
-    element.style['background-size'] = 'contain';
-    element.style['background-position'] = 'center';
-    element.style['background-repeat'] = 'no-repeat';
+    element.style.setProperty('background-size', 'contain');
+    element.style.setProperty('background-position', 'center');
+    element.style.setProperty('background-repeat', 'no-repeat');
     return element;
   }
-
 
   /**
    * a flat list of all tags, associated with their DOM elements

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -139,7 +139,7 @@ export default class StudioApp {
     if (ratio > 1.0) {
       const newFontSize = Math.floor(startingFontSize / ratio);
       if (newFontSize > minimumSize) {
-        tag.element.style['font-size'] = newFontSize + 'px';
+          tag.element.style['font-size'] = newFontSize + 'px';
       } else {
         this.showFallbackText(tag);
       }
@@ -197,6 +197,19 @@ export default class StudioApp {
 
     return imageUrls;
   }
+
+  cropImage(element) {
+    element.style['background-size'] = 'cover';
+    return element;
+  }
+
+  containImage(element) {
+    element.style['background-size'] = 'contain';
+    element.style['background-position'] = 'center';
+    element.style['background-repeat'] = 'no-repeat';
+    return element;
+  }
+
 
   /**
    * a flat list of all tags, associated with their DOM elements

--- a/test/tests.js
+++ b/test/tests.js
@@ -326,3 +326,27 @@ QUnit.test('container', function(assert) {
     'it scopes tags to its container'
   );
 });
+
+QUnit.test('.cropImage crops images', function(assert) {
+  const app = new StudioApp();
+  const tag = app.tags[0];
+  const img = new Image();
+  img.src = 'http://example.com/image-tag.png';
+  tag.element.appendChild(img);
+
+  app.cropImage(tag.element)
+
+  assert.equal(tag.element.style.backgroundSize, 'cover');
+});
+
+QUnit.test('.containImage shrinks images to fit', function(assert) {
+  const app = new StudioApp();
+  const tag = app.tags[0];
+  const img = new Image();
+  img.src = 'http://example.com/image-tag.png';
+  tag.element.appendChild(img);
+
+  app.containImage(tag.element)
+
+  assert.equal(tag.element.style.backgroundSize, 'contain');
+})

--- a/test/tests.js
+++ b/test/tests.js
@@ -336,7 +336,9 @@ QUnit.test('.cropImage crops images', function(assert) {
 
   app.cropImage(tag.element)
 
-  assert.equal(tag.element.style.backgroundSize, 'cover');
+  assert.equal(tag.element.style.backgroundSize, 'unset');
+  assert.equal(tag.element.style.backgroundPosition, 'unset');
+  assert.equal(tag.element.style.backgroundRepeat, 'no-repeat');
 });
 
 QUnit.test('.containImage shrinks images to fit', function(assert) {
@@ -349,4 +351,6 @@ QUnit.test('.containImage shrinks images to fit', function(assert) {
   app.containImage(tag.element)
 
   assert.equal(tag.element.style.backgroundSize, 'contain');
+  assert.equal(tag.element.style.backgroundPosition, 'center center');
+  assert.equal(tag.element.style.backgroundRepeat, 'no-repeat');
 })


### PR DESCRIPTION
Gives StudioApp methods to set the overflow type image elements to cropped or contained, so we can consolidate the behavior of all of the studio apps.