### PR TITLE
Adds formatImageTags method

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
 
     preprocessors: {
       'test/index.html': ['html2js'],
-      'src/*.js': ['rollup'],
+      'src/**/*.js': ['rollup'],
       'test/*.js': ['rollup', 'sourcemap']
     },
 

--- a/src/dom-utils/format-image.js
+++ b/src/dom-utils/format-image.js
@@ -1,0 +1,11 @@
+export function cropImageElement(tagElement) {
+  const image = tagElement.querySelector('img');
+  image.style.setProperty('width', 'auto');
+  image.style.setProperty('height', 'auto');
+}
+
+export function containImageElement(tagElement) {
+  const image = tagElement.querySelector('img');
+  image.style.setProperty('max-width', '100%');
+  image.style.setProperty('max-height', '100%');
+}

--- a/src/studio-app.js
+++ b/src/studio-app.js
@@ -1,4 +1,5 @@
 import CD from 'cropduster';
+import { cropImageElement, containImageElement } from './dom-utils/format-image';
 
 export default class StudioApp {
   /**
@@ -198,18 +199,13 @@ export default class StudioApp {
     return imageUrls;
   }
 
-  cropImage(element) {
-    element.style.setProperty('background-size', 'unset');
-    element.style.setProperty('background-position', 'unset');
-    element.style.setProperty('background-repeat', 'no-repeat');
-    return element;
-  }
-
-  containImage(element) {
-    element.style.setProperty('background-size', 'contain');
-    element.style.setProperty('background-position', 'center');
-    element.style.setProperty('background-repeat', 'no-repeat');
-    return element;
+  formatImageTags() {
+    return this.allTags
+      .filter(({ type }) => type === 'image')
+      .forEach(
+        ({ isCropped, element }) =>
+          isCropped ? cropImageElement(element) : containImageElement(element)
+      );
   }
 
   /**

--- a/test/tests.js
+++ b/test/tests.js
@@ -327,30 +327,45 @@ QUnit.test('container', function(assert) {
   );
 });
 
-QUnit.test('.cropImage crops images', function(assert) {
-  const app = new StudioApp();
-  const tag = app.tags[0];
-  const img = new Image();
-  img.src = 'http://example.com/image-tag.png';
-  tag.element.appendChild(img);
+QUnit.test('formatImageTags', function(assert) {
+  const container = document.createElement('body');
+  const miAttributes = document.querySelector('.mi-attributes');
 
-  app.cropImage(tag.element)
+  const tags = JSON.stringify([
+    { id: 'image', type: 'image', isCropped: false },
+    { id: 'croppedImage', type: 'image', isCropped: true },
+    { id: 'banana', type: 'banana' },
+  ]);
 
-  assert.equal(tag.element.style.backgroundSize, 'unset');
-  assert.equal(tag.element.style.backgroundPosition, 'unset');
-  assert.equal(tag.element.style.backgroundRepeat, 'no-repeat');
+  const html = `
+    <div mi-tag='image'><img></div>
+    <div mi-tag='croppedImage'><img></div>
+    <div mi-tag='banana'></div>
+  `;
+
+  container.innerHTML = html;
+  miAttributes.innerHTML = tags;
+
+  const app = new StudioApp({ container });
+  app.formatImageTags();
+
+  assert.equal(
+    container.querySelector('[mi-tag="image"] img').style.getPropertyValue('max-width'),
+    '100%'
+  );
+
+  assert.equal(
+    container.querySelector('[mi-tag="image"] img').style.getPropertyValue('max-height'),
+    '100%'
+  );
+
+  assert.equal(
+    container.querySelector('[mi-tag="croppedImage"] img').style.getPropertyValue('width'),
+    'auto'
+  );
+
+  assert.equal(
+    container.querySelector('[mi-tag="croppedImage"] img').style.getPropertyValue('height'),
+    'auto'
+  );
 });
-
-QUnit.test('.containImage shrinks images to fit', function(assert) {
-  const app = new StudioApp();
-  const tag = app.tags[0];
-  const img = new Image();
-  img.src = 'http://example.com/image-tag.png';
-  tag.element.appendChild(img);
-
-  app.containImage(tag.element)
-
-  assert.equal(tag.element.style.backgroundSize, 'contain');
-  assert.equal(tag.element.style.backgroundPosition, 'center center');
-  assert.equal(tag.element.style.backgroundRepeat, 'no-repeat');
-})


### PR DESCRIPTION
### Current Behavior
Studio / Canvas adds a field for all dynamic image elements to determine how they should be displayed. This selection is exported in the Studio HTML, but only `isCropped` is exported in the Studio JSON.

### Why do we need this change?
Most of the time, the HTML Studio exports is fine and this method won't need to be called. However, in cases where new elements are being created from the tag JSON (like twitter), we need a method to handle `isCropped`.

### Implementation Details
Adds a method, which every app with dynamic image tools can call in its render method (if it needs to).

I don't think this is ideal, but I'm very confident that this is the correct approach given the constraints set by maintaining consistency between the Tag model, the `document-tag` component, the exported HTML (particularly the exported inner element, which is not saved in the JSON), and the exported JSON itself.

An alternative that I did explore was abandoning the notion of `exportedInner` altogether and just exporting CSS background-image properties on the tag model, but the implementation felt a little crazy (another 40-line method in the tag model), and I was concerned about backwards compatibility and users' expectations of image tags having an actual `img` element.

#### Dependencies (if any)
Technically none, but this Canvas PR provides the flag this uses: https://github.com/movableink/canvas/pull/2629

[:house: [ch8080]](https://app.clubhouse.io/movableink/story/8080)
